### PR TITLE
fixed typo in License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -198,6 +198,6 @@ Copyright (C) 2012 Adobe Systems Incorporated. All rights reserved.
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either expressed or implied.
    See the License for the specific language governing permissions and
    limitations under the License.


### PR DESCRIPTION
Fixed a small typo: express -> expressed
