### PR TITLE
Fix GitHub link in footer

### DIFF
--- a/src/layouts/default.html.jade
+++ b/src/layouts/default.html.jade
@@ -196,7 +196,7 @@ html(lang='en')
                 footer.site
                     ul
                         li#twitter: a(href="http://twitter.com/topcoat")
-                        li#github: a(href="http://github.com/topcoat")
+                        li#github: a(href="http://github.com/topcoat/topcoat")
                         li#adobe: a(href="http://html.adobe.com")
         != getBlock('scripts').toHTML()
         script(type="text/javascript").


### PR DESCRIPTION
Point GitHub link in footer directly to Topcoat GitHub repository. See topcoat/topcoat#446.
